### PR TITLE
Add GitHub deployment traceability

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -66,6 +66,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             APP_VERSION=${{ steps.version.outputs.app_version }}
+            VCS_REF=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ Read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) before participating in project sp
 
 ## Development workflow
 
+Maintainers and operators should also read [GitHub development and deployment workflow](docs/GITHUB-WORKFLOW.md).
+
 1. Fork the repository.
 2. Create a focused branch.
 3. Read the relevant source, tests and `AGENTS.md` before changing behaviour.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.13-slim
 
 ARG APP_VERSION=2.7.0
+ARG VCS_REF=""
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    RADAR_BUILD_COMMIT="${VCS_REF}"
 
 LABEL org.opencontainers.image.title="Software Release Radar" \
       org.opencontainers.image.description="Self-hosted software release monitoring and upgrade review dashboard" \
       org.opencontainers.image.version="${APP_VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.licenses="AGPL-3.0-only" \
       org.opencontainers.image.source="https://github.com/muhdusama/Software-Release-Radar"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         APP_VERSION: "${RADAR_VERSION:-2.7.0}"
+        VCS_REF: "${RADAR_BUILD_COMMIT:-}"
     restart: unless-stopped
     env_file:
       - .env
@@ -31,6 +32,7 @@ services:
       context: .
       args:
         APP_VERSION: "${RADAR_VERSION:-2.7.0}"
+        VCS_REF: "${RADAR_BUILD_COMMIT:-}"
     restart: unless-stopped
     env_file:
       - .env
@@ -53,6 +55,7 @@ services:
       context: .
       args:
         APP_VERSION: "${RADAR_VERSION:-2.7.0}"
+        VCS_REF: "${RADAR_BUILD_COMMIT:-}"
     restart: unless-stopped
     env_file:
       - .env

--- a/docs/GITHUB-WORKFLOW.md
+++ b/docs/GITHUB-WORKFLOW.md
@@ -1,0 +1,135 @@
+# GitHub development and deployment workflow
+
+GitHub is the source of truth for Software Release Radar. Development changes should move from a writable development checkout into a branch and pull request, pass GitHub Actions, and reach production only after review and merge.
+
+## Separation of responsibilities
+
+| Location | Purpose | GitHub access |
+|---|---|---|
+| Development checkout | Edit, test, commit and push branches | Write access through a dedicated SSH key or GitHub CLI |
+| GitHub Actions | Run tests, security checks and public Docker acceptance | Repository-scoped workflow token |
+| Production checkout | Fetch approved source and deploy it | Read-only HTTPS access is sufficient for this public repository |
+| GitHub Container Registry | Store tagged multi-architecture release images | Anonymous pull access for the public package |
+
+Do not store a GitHub write token or a maintainer SSH key on the production host. Production should not push source changes.
+
+Do not attach a production host as a self-hosted runner for this public repository. Pull requests and forked code must not receive an execution path into production infrastructure.
+
+## Development setup
+
+Clone the repository on the development machine:
+
+```bash
+git clone git@github.com:muhdusama/Software-Release-Radar.git
+cd Software-Release-Radar
+git remote -v
+```
+
+Create a focused branch for each change:
+
+```bash
+git switch main
+git pull --ff-only
+git switch -c feature/descriptive-name
+```
+
+Run the project checks before pushing:
+
+```bash
+python -m unittest discover -s tests -v
+docker compose config
+```
+
+Then publish the branch and open a pull request:
+
+```bash
+git push -u origin feature/descriptive-name
+gh pr create --draft --fill
+```
+
+GitHub Actions must pass before the change is merged into `main`.
+
+## Existing installations
+
+Do not immediately replace the remote or source tree of an installation that predates the public GitHub release. First determine whether the live directory is a Git worktree and whether it contains private deployment files, bind mounts or local configuration that are intentionally absent from the public repository.
+
+The safe migration pattern is:
+
+1. leave the running installation unchanged;
+2. create an adjacent clean checkout from GitHub;
+3. compare the clean checkout with the live deployment source;
+4. preserve `.env`, database storage, SSH material, backups and deployment-only files;
+5. build and test a candidate against copied or isolated state;
+6. deploy through the existing backup and rollback process; and
+7. change the live source relationship only after the candidate passes.
+
+When retaining an older source remote for reference, use a separate remote name such as `gitea`. Keep `origin` pointed at GitHub in the active development checkout.
+
+## Deploying an approved revision
+
+Create a verified backup before changing source:
+
+```bash
+./scripts/backup.sh
+```
+
+Fetch and fast-forward the deployment checkout:
+
+```bash
+git fetch origin --prune
+git switch main
+git merge --ff-only origin/main
+```
+
+Embed the exact source revision in the locally built image:
+
+```bash
+export RADAR_BUILD_COMMIT="$(git rev-parse HEAD)"
+docker compose config
+docker compose build --pull
+docker compose up -d --build
+```
+
+Confirm the application and workers are healthy:
+
+```bash
+docker compose ps
+curl -fsS http://localhost:9120/healthz
+```
+
+When a build revision was supplied, the health response includes a `commit` field:
+
+```json
+{"commit":"0123456789abcdef0123456789abcdef01234567","name":"Software Release Radar","status":"ok","version":"2.7.0"}
+```
+
+The same revision is stored in the container image label:
+
+```bash
+docker image inspect \
+  --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+  "software-release-radar:$(tr -d '[:space:]' < VERSION)"
+```
+
+This makes it possible to confirm that the running application matches the intended merged GitHub revision.
+
+## Tagged releases and GHCR
+
+A tag matching `v<VERSION>` runs the container publishing workflow. The workflow builds `linux/amd64` and `linux/arm64` images and records the tagged GitHub commit in both the image environment and the OCI revision label.
+
+Example verification:
+
+```bash
+docker pull ghcr.io/muhdusama/software-release-radar:2.7.0
+docker image inspect \
+  --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+  ghcr.io/muhdusama/software-release-radar:2.7.0
+```
+
+Release tags are immutable deployment references. Normal development should use branches and pull requests rather than committing directly on a production host.
+
+## Rollback boundary
+
+A Git rollback is not a database rollback. Preserve a verified database backup before every upgrade and follow the restore procedure in [Docker deployment](DOCKER.md) when application state must be restored.
+
+Review `CHANGELOG.md` and release notes before deploying a new version. A future migration that changes database compatibility must include explicit upgrade and rollback instructions.

--- a/radar/application.py
+++ b/radar/application.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from flask import Flask
 
 from .auth_rate_limit import install_auth_rate_limits
+from .build_info import install_build_metadata
 from .web import create_app as create_web_app
 
 
@@ -10,4 +11,5 @@ def create_app() -> Flask:
     """Create the public application with production security extensions."""
     app = create_web_app()
     install_auth_rate_limits(app)
+    install_build_metadata(app)
     return app

--- a/radar/build_info.py
+++ b/radar/build_info.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+import re
+from functools import wraps
+from typing import Any
+
+from flask import Flask
+
+_GIT_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
+
+
+def build_commit() -> str | None:
+    """Return the validated source revision embedded in this build, when available."""
+    value = os.environ.get("RADAR_BUILD_COMMIT", "").strip()
+    if not _GIT_COMMIT_RE.fullmatch(value):
+        return None
+    return value.lower()
+
+
+def install_build_metadata(app: Flask) -> None:
+    """Add the validated source revision to the existing health response."""
+    health_view = app.view_functions.get("healthz")
+    if health_view is None:
+        raise RuntimeError(
+            "The healthz endpoint must be registered before build metadata is installed."
+        )
+
+    @wraps(health_view)
+    def healthz_with_build_metadata(*args: Any, **kwargs: Any):
+        result = health_view(*args, **kwargs)
+        commit = build_commit()
+        if commit and isinstance(result, dict):
+            payload = dict(result)
+            payload["commit"] = commit
+            return payload
+        return result
+
+    app.view_functions["healthz"] = healthz_with_build_metadata

--- a/tests/test_build_info.py
+++ b/tests/test_build_info.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from flask import Flask
+
+from radar.build_info import build_commit, install_build_metadata
+
+
+def _test_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.get("/healthz")
+    def healthz():
+        return {"status": "ok", "version": "test", "name": "Software Release Radar"}
+
+    install_build_metadata(app)
+    return app
+
+
+class BuildInfoTests(unittest.TestCase):
+    def test_valid_build_commit_is_normalised_and_exposed(self):
+        commit = "ABCDEF1234567890ABCDEF1234567890ABCDEF12"
+        with patch.dict(os.environ, {"RADAR_BUILD_COMMIT": commit}, clear=False):
+            self.assertEqual(build_commit(), commit.lower())
+            payload = _test_app().test_client().get("/healthz").get_json()
+
+        self.assertEqual(payload["commit"], commit.lower())
+        self.assertEqual(payload["status"], "ok")
+
+    def test_invalid_build_commit_is_omitted(self):
+        with patch.dict(os.environ, {"RADAR_BUILD_COMMIT": "main"}, clear=False):
+            self.assertIsNone(build_commit())
+            payload = _test_app().test_client().get("/healthz").get_json()
+
+        self.assertNotIn("commit", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed?

- documented a GitHub-first development workflow with pull-only production deployments
- added a safe migration pattern for installations created before the clean public GitHub history
- embedded the exact GitHub commit in locally built and published container images
- exposed the validated build revision through `/healthz`
- added focused tests for valid and invalid revision metadata

## Why?

Existing deployments need a safe source-of-truth relationship with GitHub without placing maintainer write credentials on the production host. Recording the revision in both the health response and OCI image label makes it possible to prove which approved GitHub commit is running.

## Validation

- [x] Complete Python test suite passes in GitHub Actions
- [x] Dependency and Python security audit passes
- [x] Public Docker setup and recovery acceptance passes
- [x] Docker Compose configuration remains valid
- [x] Existing production migration to the clean v2.7.0 GitHub baseline completed with all 72 trackers preserved and SQLite integrity verified

## Security and upgrade impact

- no database migration
- no new dependency
- no new network access
- production remains pull-only
- invalid or missing revision values are omitted rather than trusted

## AI-assisted work

This change was prepared with AI assistance and remains subject to the repository tests and maintainer review.