### PR TITLE
Fix background worker health status

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       RADAR_DB: /data/radar.db
       RADAR_SSH_DIR: /ssh
     command: ["python", "-m", "radar.scheduler"]
+    healthcheck:
+      disable: true
     depends_on:
       radar:
         condition: service_healthy
@@ -63,6 +65,8 @@ services:
       RADAR_DB: /data/radar.db
       RADAR_SSH_DIR: /ssh
     command: ["python", "-m", "radar.portainer_worker"]
+    healthcheck:
+      disable: true
     depends_on:
       radar:
         condition: service_healthy

--- a/tests/test_worker_healthchecks.py
+++ b/tests/test_worker_healthchecks.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+class WorkerHealthcheckTests(unittest.TestCase):
+    def test_non_web_services_disable_image_http_healthcheck(self):
+        compose = (Path(__file__).parents[1] / "docker-compose.yml").read_text()
+
+        scheduler = compose.split("  scheduler:\n", 1)[1].split("\n  portainer-worker:\n", 1)[0]
+        worker = compose.split("  portainer-worker:\n", 1)[1].split("\nvolumes:\n", 1)[0]
+
+        for service in (scheduler, worker):
+            self.assertIn("healthcheck:\n      disable: true", service)
+            self.assertNotIn("http://127.0.0.1:8080/healthz", service)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed?

- disable the inherited image HTTP health check for the scheduler
- disable the inherited image HTTP health check for the Portainer worker
- keep the real `/healthz` check on the web service only
- add regression coverage so background services cannot accidentally inherit the web-only health check again

## Why?

All three Compose services use the same image. The image defines an HTTP health check against `127.0.0.1:8080/healthz`. The scheduler and Portainer worker do not run the web server, so Docker can leave them at `starting` and later mark them `unhealthy` even while their processes are running normally.

## Impact

This does not change application logic, data, networking, or worker restart behaviour. It only removes an invalid health probe from non-web services.

## Validation

GitHub Actions must pass before merge.