### PR TITLE
Remove Ko-fi support links

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,6 @@ Software Release Radar is a side project I am building and maintaining while I l
 
 <p align="center">
   <a href="https://buymeacoffee.com/muhdusama"><img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-Support-FFDD00?logo=buymeacoffee&logoColor=000000" alt="Support on Buy Me a Coffee"></a>
-  <a href="https://ko-fi.com/muhdusama"><img src="https://img.shields.io/badge/Ko--fi-Support-FF5E5B?logo=kofi&logoColor=white" alt="Support on Ko-fi"></a>
   <a href="https://www.paypal.com/paypalme/muhdusama"><img src="https://img.shields.io/badge/PayPal-Donate-003087?logo=paypal&logoColor=white" alt="Donate with PayPal"></a>
 </p>
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,7 +7,6 @@ If the project saves you time or is useful in your environment, any support is a
 ## Support development
 
 - **Buy Me a Coffee:** https://buymeacoffee.com/muhdusama
-- **Ko-fi:** https://ko-fi.com/muhdusama
 - **PayPal:** https://www.paypal.com/paypalme/muhdusama
 
 The repository also includes `.github/FUNDING.yml` so these funding options can be exposed through the GitHub Sponsor button when repository sponsorships are enabled.


### PR DESCRIPTION
## Summary

Remove the Ko-fi support link from the public repository page and support documentation.

## Changes

- remove the Ko-fi badge from the README support section
- remove the Ko-fi entry from `SUPPORT.md`
- retain Buy Me a Coffee and PayPal
- keep the already updated GitHub funding configuration without Ko-fi

## Validation

- documentation-only change
- no application code, database schema, runtime settings, secrets or production services are changed
