### PR TITLE
Document Dockhand merge and contributor credit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Added
 
+- Dockhand support as an alternative Docker inventory provider alongside Portainer, including encrypted API-token storage, provider-specific synchronisation, environment availability checks and inventory normalisation.
 - A clearly labelled Global defaults section for inherited software notification behaviour and delivery channels.
+
+### Changed
+
+- Docker inventory integration now uses a provider abstraction while preserving the existing Portainer-compatible database and Compose service names for backwards-compatible upgrades.
+- Provider switching keeps existing tracker mappings attached to their original provider until an administrator explicitly imports and rebinds the corresponding service from the active provider.
 
 ### Fixed
 
+- Inventory probes now fail closed when a tracker mapping belongs to a different provider than the currently active inventory provider, preventing stale cross-provider version or state reporting.
+- Offline or malformed Dockhand environment responses preserve last-known-good inventory instead of incorrectly marking existing containers absent.
+- Dockhand due-sync scheduling now uses Dockhand-specific timing settings, and Dockhand origin validation rejects embedded credentials, paths, queries and fragments.
 - Per-software notification preference changes now save immediately without reloading the Notifications page.
 - Bulk software preferences and global notification defaults now save without clearing the current software filter.
 - The Notifications software search is retained for the browser session, including after a manual refresh.
+
+### Validated
+
+- PR #15 passed the complete Python 3.13 regression suite, dependency and Bandit security audit, and public Docker setup, backup, restore and persistent-state acceptance workflow before merge.
 
 ---
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@ Software Release Radar is built with human direction and extensive AI-assisted d
 | Contributor | Role |
 |---|---|
 | [@muhdusama](https://github.com/muhdusama) | Creator and maintainer. Product direction, feature decisions, real-world testing, release decisions and project stewardship. |
+| [@KoshiirRa](https://github.com/KoshiirRa) | Human contributor. Added Dockhand inventory-provider compatibility, including provider integration, documentation, regression coverage and follow-up fixes from maintainer review. |
 | **OpenAI Codex** | AI coding contributor. Used extensively for implementation, refactoring, tests, debugging, documentation and code review assistance. |
 
 ## About the Codex credit


### PR DESCRIPTION
## Summary

Follow-up documentation after merging #15.

- records the Dockhand inventory-provider work under **Unreleased** in `CHANGELOG.md`;
- records the final provider-switch fail-closed fix and validation outcome;
- credits @KoshiirRa in `CONTRIBUTORS.md` for the Dockhand contribution.

No runtime code, dependencies, workflows or deployment behaviour are changed.