### PR TITLE
Refresh maintenance notes and roadmap visual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 - Docker inventory integration now uses a provider abstraction while preserving the existing Portainer-compatible database and Compose service names for backwards-compatible upgrades.
 - Provider switching keeps existing tracker mappings attached to their original provider until an administrator explicitly imports and rebinds the corresponding service from the active provider.
+- Gunicorn's minimum supported version is now 26.2.0.
+- `cryptography`'s minimum supported version is now 50.0.1.
+- `regex`'s minimum supported version is now 2026.9.3.
+- `docker/setup-qemu-action` is updated from v4.2.0 to v4.3.0 using its immutable commit SHA.
 
 ### Fixed
 
@@ -25,9 +29,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Bulk software preferences and global notification defaults now save without clearing the current software filter.
 - The Notifications software search is retained for the browser session, including after a manual refresh.
 
+### Security
+
+- Gunicorn 26.2.0 includes upstream HTTP/2 request-policy hardening.
+- Dependency minimums were refreshed after upstream security and reliability maintenance in `cryptography` and `regex`.
+
 ### Validated
 
 - PR #15 passed the complete Python 3.13 regression suite, dependency and Bandit security audit, and public Docker setup, backup, restore and persistent-state acceptance workflow before merge.
+- PRs #22 through #25 each passed the required Python 3.13 tests, dependency and Bandit security audit, and public Docker setup and recovery acceptance workflow on their final merge heads.
 
 ---
 

--- a/FEATURE_VOTING.md
+++ b/FEATURE_VOTING.md
@@ -88,13 +88,13 @@ A poll may include 4 to 8 options such as:
 
 When unrelated ideas would make a poll confusing, polls can be grouped by theme.
 
-### Planned public setup
+### Current public setup
 
-After public launch:
+The public project uses:
 
-- **GitHub Issues** will hold detailed feature proposals;
-- **👍 reactions** will provide a persistent demand signal; and
-- **GitHub Discussions polls** will be used for direct roadmap comparisons.
+- **GitHub Issues** for detailed feature proposals;
+- **👍 reactions** as a persistent demand signal; and
+- **GitHub Discussions polls** for direct roadmap comparisons when useful.
 
 ---
 
@@ -124,7 +124,7 @@ The reverse is also true. A low-vote security fix may move immediately because p
 
 ## 📝 Writing a useful feature request
 
-A strong request explains the problem you are trying to solve, what you do today instead, who would benefit, whether it affects Docker, Portainer or another deployment model, any privacy or security considerations, and what a good result would look like.
+A strong request explains the problem you are trying to solve, what you do today instead, who would benefit, whether it affects Docker, Portainer, Dockhand or another deployment model, any privacy or security considerations, and what a good result would look like.
 
 **Describe the problem before prescribing the implementation.** There may be a simpler or safer way to solve the same need.
 
@@ -140,9 +140,9 @@ When a roadmap poll changes priorities, the roadmap should be updated so the res
 
 ## 📍 Current state
 
-The first priority is the safe public release of **v2.7.0**.
+The public release baseline is established at **v2.8.0**, and ongoing maintenance is active.
 
-Feature voting can collect ideas now, but larger feature work should not displace the final privacy audit, clean public Git history and publication safety checks needed before the repository becomes public.
+Feature voting can now help prioritise improvements, while security, data integrity, deterministic monitoring, backwards compatibility and reliable self-hosted upgrades remain release gates for every change.
 
 <p align="center">
   <strong>Next stop:</strong> <a href="ROADMAP.md">view the roadmap</a>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,12 +6,11 @@
 
 Software Release Radar is a public self-hosted project designed so another person can install, understand and operate it without knowing anything about the private environment where it was created.
 
-The first public release is **v2.7.0**.
+The first public release is **v2.7.0**. The current public release baseline is **v2.8.0**, with ongoing maintenance active.
 
 <p align="center">
   <a href="#-current-position">📍 Current position</a> ·
-  <a href="#-final-publication-gates">🔒 Final gates</a> ·
-  <a href="#-next-community-ready-foundation">🔵 Next</a> ·
+  <a href="#-current-ongoing-maintenance-and-community-ready-foundation">🔵 Current</a> ·
   <a href="#-then-better-release-intelligence">🟣 Then</a> ·
   <a href="#-later-fleet-and-integrations">🟠 Later</a> ·
   <a href="#-feature-voting-and-roadmap-polls">🗳️ Vote</a>
@@ -23,9 +22,10 @@ The first public release is **v2.7.0**.
 
 | Area | Status | Notes |
 |---|---|---|
+| Current public release | ✅ v2.8.0 | Current version recorded in `VERSION` and the changelog |
 | Sanitised application source | ✅ Passed | Imported without private Gitea history |
 | AGPL-3.0 licensing | ✅ Passed | Repository licence is GNU AGPL-3.0 |
-| Docker image and Compose stack | ✅ Passed | Web app, automatic scheduler and Portainer worker |
+| Docker image and Compose stack | ✅ Passed | Web app, automatic scheduler and inventory worker |
 | Docker-only first-run setup | ✅ Passed | Tested on a clean GitHub Actions runner and macOS Docker Desktop |
 | Automatic release checking | ✅ Passed | Due-only scheduler is part of the standard Compose stack |
 | Backup and guarded restore | ✅ Passed | Online backup, integrity checks, safety copy and rollback path tested |
@@ -33,11 +33,13 @@ The first public release is **v2.7.0**.
 | Python regression suite | ✅ Passed | Runs on every push and pull request |
 | Dependency vulnerability audit | ✅ Passed | `pip-audit` is a blocking CI gate |
 | Static security review | ✅ Passed | Bandit gate rejects unexpected high-confidence findings |
+| Inventory providers | ✅ Portainer + Dockhand | Provider switching, reconciliation and fail-closed mismatch handling are covered |
+| Maintenance dependency baseline | ✅ Current | Gunicorn ≥26.2.0, `cryptography` ≥50.0.1, `regex` ≥2026.9.3 and QEMU action v4.3.0 |
 | Clean macOS UX acceptance | ✅ Passed | Clean deployment visually reviewed at normal desktop use |
 | Community files and funding | ✅ Passed | Issues, PR template, Discussions, Dependabot and support links |
-| v2.7.0 version freeze | ✅ Passed | Runtime and release metadata are aligned |
-| Final privacy and secret scan | ✅ Passed | Frozen tracked tree and staging history scanned |
-| Clean public Git history | ✅ Passed | Publication starts from a new sanitised root |
+| v2.7.0 version freeze | ✅ Passed | Historical first-public-release gate |
+| Final privacy and secret scan | ✅ Passed | Frozen tracked tree and staging history scanned before public launch |
+| Clean public Git history | ✅ Passed | Publication started from a new sanitised root |
 | GitHub safety settings | ✅ Launch gate | Applied or reviewed during publication |
 | Public launch | ✅ v2.7.0 | First public release |
 
@@ -81,7 +83,7 @@ The first public release is **v2.7.0**.
 - CSRF protection.
 - Encrypted stored integration secrets.
 - Login and reset-request throttling.
-- Portainer TLS verification enabled by default.
+- Inventory-provider TLS verification enabled by default.
 - Reverse-proxy header trust disabled by default.
 - Validated OpenAI-compatible HTTP or HTTPS endpoint configuration.
 - Strict SSH host-key checking for optional Docker probes.
@@ -114,16 +116,18 @@ The release process also removes obsolete staging releases and workflow history 
 
 ---
 
-# 🔵 Next: Community-ready foundation
+# 🔵 Current: Ongoing maintenance and community-ready foundation
 
-> **Goal:** learn from real users without making the application harder to maintain.
+> **Goal:** keep the public baseline secure, dependable and easy to operate while learning from real users.
 
 <table>
 <tr>
 <td width="50%" valign="top">
 
-### 🧰 Easier self-hosting
+### 🧰 Reliable self-hosting
 
+- [x] Support both Portainer and Dockhand inventory providers.
+- [x] Keep dependency and GitHub Action updates behind the full CI gate.
 - [ ] Optional demo-data mode for evaluation.
 - [ ] Better guided diagnostics for common configuration errors.
 - [ ] Tested reverse-proxy examples based on community demand.
@@ -161,7 +165,7 @@ The release process also removes obsolete staging releases and workflow history 
 | 🧾 **Historical timelines** | Make past release decisions and deployments easier to review |
 | 🔌 **More upstream sources** | Expand beyond the initial GitHub-focused model where there is a real use case |
 
-These are candidates for community voting after the first public release is stable.
+These remain candidates for community voting as real-world usage and demand become clearer.
 
 ---
 
@@ -169,7 +173,7 @@ These are candidates for community voting after the first public release is stab
 
 > **Goal:** support larger and more varied self-hosted environments without turning the project into a fragile automation platform.
 
-- [ ] Continue strengthening Portainer inventory and container rebinding.
+- [ ] Continue strengthening Portainer and Dockhand inventory, provider parity and container rebinding.
 - [ ] Explore Docker and Compose metadata discovery where it remains predictable.
 - [ ] Add documented integration points for external monitoring and inventory systems.
 - [ ] Add notification providers based on real demand.
@@ -213,12 +217,12 @@ Read **[FEATURE_VOTING.md](FEATURE_VOTING.md)** for the full process.
 
 | Candidate area | Poll state | Community signal |
 |---|---|---|
-| More upstream release sources | 💤 Not open yet | Opens after public launch |
-| Improved release-note comparison | 💤 Not open yet | Opens after public launch |
-| Docker and Compose discovery | 💤 Not open yet | Opens after public launch |
-| More notification providers | 💤 Not open yet | Opens after public launch |
-| Read-only API and integrations | 💤 Not open yet | Opens after public launch |
-| Dashboard and fleet UX | 💤 Not open yet | Opens after public launch |
+| More upstream release sources | 💡 Candidate | Open to proposals and demand signals |
+| Improved release-note comparison | 💡 Candidate | Open to proposals and demand signals |
+| Docker and Compose discovery | 💡 Candidate | Open to proposals and demand signals |
+| More notification providers | 💡 Candidate | Open to proposals and demand signals |
+| Read-only API and integrations | 💡 Candidate | Open to proposals and demand signals |
+| Dashboard and fleet UX | 💡 Candidate | Open to proposals and demand signals |
 
 ---
 

--- a/docs/images/roadmap-journey.svg
+++ b/docs/images/roadmap-journey.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="980" viewBox="0 0 1200 980" role="img" aria-labelledby="title desc">
   <title id="title">Software Release Radar roadmap journey</title>
-  <desc id="desc">A large five-stage roadmap showing public release readiness, community foundation, release intelligence, integrations and exploratory assistance.</desc>
+  <desc id="desc">A five-stage roadmap showing ongoing maintenance, community foundation, release intelligence, integrations and exploratory assistance.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#0b1220"/>
@@ -25,9 +25,9 @@
       <circle cx="48" cy="65" r="34" fill="#173f4a" stroke="#63e6ff" stroke-width="5"/>
       <text x="48" y="65" text-anchor="middle" dominant-baseline="middle" fill="#63e6ff" font-size="20" font-weight="800">NOW</text>
       <rect x="105" y="0" width="990" height="130" rx="24" fill="#131e33" stroke="#2f6170" stroke-width="2"/>
-      <text x="142" y="34" dominant-baseline="middle" fill="#63e6ff" font-size="19" font-weight="750">PUBLIC RELEASE READINESS</text>
-      <text x="142" y="72" dominant-baseline="middle" fill="#f8fafc" font-size="31" font-weight="750">Freeze, audit and ship v2.7.0</text>
-      <text x="142" y="108" dominant-baseline="middle" fill="#a8b4c7" font-size="20">Final privacy scan, clean public history, GitHub safety settings and launch review.</text>
+      <text x="142" y="34" dominant-baseline="middle" fill="#63e6ff" font-size="19" font-weight="750">ONGOING MAINTENANCE</text>
+      <text x="142" y="72" dominant-baseline="middle" fill="#f8fafc" font-size="31" font-weight="750">Keep releases secure, current and reliable</text>
+      <text x="142" y="108" dominant-baseline="middle" fill="#a8b4c7" font-size="20">Dependency updates, regression coverage, secure upgrades and contributor review.</text>
     </g>
 
     <g transform="translate(80 305)">
@@ -36,7 +36,7 @@
       <rect x="105" y="0" width="990" height="130" rx="24" fill="#131e33" stroke="#30455f" stroke-width="2"/>
       <text x="142" y="34" dominant-baseline="middle" fill="#7dd3fc" font-size="19" font-weight="750">COMMUNITY FOUNDATION</text>
       <text x="142" y="72" dominant-baseline="middle" fill="#f8fafc" font-size="31" font-weight="750">Make self-hosting and contribution easy</text>
-      <text x="142" y="108" dominant-baseline="middle" fill="#a8b4c7" font-size="20">Better diagnostics, demo data, contributor-friendly issues and upgrade guidance.</text>
+      <text x="142" y="108" dominant-baseline="middle" fill="#a8b4c7" font-size="20">Better diagnostics, upgrade guidance, community issues and low-friction contribution.</text>
     </g>
 
     <g transform="translate(80 450)">
@@ -54,7 +54,7 @@
       <rect x="105" y="0" width="990" height="130" rx="24" fill="#131e33" stroke="#4d3a70" stroke-width="2"/>
       <text x="142" y="34" dominant-baseline="middle" fill="#a78bfa" font-size="19" font-weight="750">FLEET AND INTEGRATIONS</text>
       <text x="142" y="72" dominant-baseline="middle" fill="#f8fafc" font-size="31" font-weight="750">Broaden how Release Radar connects</text>
-      <text x="142" y="108" dominant-baseline="middle" fill="#a8b4c7" font-size="20">Fleet discovery, stable APIs, providers and stronger Portainer workflows.</text>
+      <text x="142" y="108" dominant-baseline="middle" fill="#a8b4c7" font-size="20">Stable APIs, more providers and stronger self-hosted integration workflows.</text>
     </g>
 
     <g transform="translate(80 740)">


### PR DESCRIPTION
## Summary

Post-maintenance reconciliation after merging Dependabot PRs #22 through #25.

- records the Gunicorn, cryptography, regex and QEMU action updates under **Unreleased**;
- refreshes the roadmap from the obsolete v2.7.0 launch state to the current v2.8.0 ongoing-maintenance state;
- updates feature-voting guidance now that the public release baseline is established;
- refreshes the roadmap journey SVG while preserving the existing visual style;
- leaves the neutral dashboard, fleet, review-queue and feature-voting reference images unchanged because they do not contain stale release or provider state.

No runtime code, dependencies, deployment configuration or workflow behaviour are changed by this PR.